### PR TITLE
Use query instead of memory heavy craft cms api

### DIFF
--- a/services/AssetUsage_AssetService.php
+++ b/services/AssetUsage_AssetService.php
@@ -13,11 +13,29 @@ class AssetUsage_AssetService extends BaseApplicationComponent
      */
     public function getUsage(AssetFileModel $asset)
     {
+
+        // Use fast query instead of memory consuming method
+        $results = craft()->db->createCommand()
+          ->select( array('id') )
+          ->from( array('{{relations}}') )
+          ->where( array('targetId' => $asset->id) )
+          ->orWhere( array('sourceId' => $asset->id) )
+          ->queryAll();
+
+        $count = count($results);
+        if ($count >= 1) {
+          return Craft::t('Used') . ': ' . $count . 'x';
+        } else {
+          return '<span style="color: #da5a47;">' . Craft::t('Unused') . '</span>';
+        }
+
+        /*
         if (in_array($asset->id, $this->getUsedAssetIds())) {
             return Craft::t('Used');
         }
 
         return '<span style="color: #da5a47;">' . Craft::t('Unused') . '</span>';
+        */
     }
 
     /**


### PR DESCRIPTION
Uses the query on the craft_relations table for getting the usage of an asset (See Craft CMS v3 version of this plugin). This saves a lot of memory usage, which caused our project to not show any images anymore.