### PR TITLE
Added site check to current usage

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -31,7 +31,9 @@ class Plugin extends CraftPlugin
         parent::init();
         self::$plugin = $this;
 
-        if (!$this->isInstalled) return;
+        if (!$this->isInstalled) {
+            return;
+        }
 
         // Register Components (Services)
         $this->setComponents([
@@ -49,7 +51,7 @@ class Plugin extends CraftPlugin
          *
          * @return array
          */
-        Event::on(Asset::class, Asset::EVENT_REGISTER_TABLE_ATTRIBUTES, function(RegisterElementTableAttributesEvent $event) {
+        Event::on(Asset::class, Asset::EVENT_REGISTER_TABLE_ATTRIBUTES, function (RegisterElementTableAttributesEvent $event) {
             $event->tableAttributes['usage'] = [
                 'label' => Craft::t('assetusage', 'Usage'),
             ];
@@ -59,7 +61,7 @@ class Plugin extends CraftPlugin
             ];
         });
 
-        Event::on(Asset::class, Asset::EVENT_SET_TABLE_ATTRIBUTE_HTML, function(SetElementTableAttributeHtmlEvent $event) {
+        Event::on(Asset::class, Asset::EVENT_SET_TABLE_ATTRIBUTE_HTML, function (SetElementTableAttributeHtmlEvent $event) {
             if ($event->attribute === 'usage') {
                 /** @var Asset $asset */
                 $asset = $event->sender;

--- a/src/services/Asset.php
+++ b/src/services/Asset.php
@@ -38,14 +38,14 @@ class Asset extends Component
     public function getCurrentUsage(AssetElement $asset)
     {
         $results = (new Query())
-          ->select(['sourceId'])
+          ->select(['sourceId', 'sourceSiteId'])
           ->from(Table::RELATIONS)
           ->where(['targetId' => $asset->id])
-          ->column();
+          ->all();
 
         $elementIds = [];
         foreach ($results as $result) {
-            $element = Craft::$app->elements->getElementById($result);
+            $element = Craft::$app->elements->getElementById($result['sourceId'], null, $result['sourceSiteId']);
 
             if (isset($element)) {
                 $currentRevision = $element->getCurrentRevision();
@@ -59,13 +59,14 @@ class Asset extends Component
         $count = count($elementIds);
 
         return $this->formatResults($count);
+        return "lol";
     }
 
     private function formatResults($count)
     {
         if ($count === 1) {
             return Craft::t('assetusage', 'Used {count} time', [ 'count' => $count ]);
-        } else if ($count > 1) {
+        } elseif ($count > 1) {
             return Craft::t('assetusage', 'Used {count} times', [ 'count' => $count ]);
         }
 


### PR DESCRIPTION
Since current site is not available and is always the default one, fetch the element site from the Relations table and get element with the site information, to have correct current usage count in multisite installs.