### PR TITLE
Add support for Hyper asset relations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     },
     "require-dev": {
         "craftcms/ecs": "dev-main",
-        "craftcms/phpstan": "dev-main"
+        "craftcms/phpstan": "dev-main",
+        "verbb/hyper": "^2.0.0"
     },
     "scripts": {
         "phpstan": "phpstan --ansi --memory-limit=1G",

--- a/src/console/controllers/DefaultController.php
+++ b/src/console/controllers/DefaultController.php
@@ -5,6 +5,8 @@ namespace roelvanhintum\assetusage\console\controllers;
 use Craft;
 use craft\db\Query;
 use craft\db\Table;
+use craft\elements\Asset;
+use verbb\hyper\records\ElementCache as HyperElementCache;
 use yii\console\Controller;
 use yii\console\ExitCode;
 
@@ -93,6 +95,15 @@ class DefaultController extends Controller
             ->where(['elements.dateDeleted' => null])
             ->andWhere(['not exists', $subQueryRelations])
             ->andWhere(['not exists', $subQueryContent]);
+
+        if (Craft::$app->getPlugins()->isPluginEnabled('hyper')) {
+            $subQueryHyper = (new Query())
+                ->select('id')
+                ->from(['hyper_element_cache' => HyperElementCache::tableName()])
+                ->where('[[hyper_element_cache.targetId]] = [[assets.id]]')
+                ->andWhere(['targetType' => Asset::class]);
+            $query->andWhere(['not exists', $subQueryHyper]);
+        }
 
         if (isset($volumeModel)) {
             $query->where(['volumeId' => $volumeModel->id]);

--- a/src/services/Asset.php
+++ b/src/services/Asset.php
@@ -9,6 +9,7 @@ use craft\db\Table;
 use craft\elements\Asset as AssetElement;
 use craft\helpers\ElementHelper;
 use roelvanhintum\assetusage\Plugin;
+use verbb\hyper\records\ElementCache as HyperElementCache;
 
 class Asset extends Component
 {
@@ -21,7 +22,11 @@ class Asset extends Component
      */
     public function getUsageCount(AssetElement $asset): string
     {
-        $relations = array_merge($this->queryRelations($asset), $this->queryContents($asset));
+        $relations = array_merge(
+            $this->queryRelations($asset),
+            $this->queryContents($asset),
+            $this->queryHyperElementCache($asset)
+        );
 
         if (Plugin::getInstance()->settings->includeRevisions) {
             return $this->formatResults(count($relations));
@@ -49,7 +54,11 @@ class Asset extends Component
      */
     public function getUsedIn(AssetElement $asset): array
     {
-        $relations = array_merge($this->queryRelations($asset), $this->queryContents($asset));
+        $relations = array_merge(
+            $this->queryRelations($asset),
+            $this->queryContents($asset),
+            $this->queryHyperElementCache($asset)
+        );
 
         $elements = [];
 
@@ -89,7 +98,7 @@ class Asset extends Component
         $query = (new Query())
         ->select(['elementId as id', 'siteId'])
         ->from(Table::ELEMENTS_SITES);
-    
+
         // PostgreSQL requires explicit casting for JSONB columns
         if (Craft::$app->getDb()->getIsPgsql()) {
             $query->where(['like', 'CAST(content AS TEXT)', "asset:{$asset->id}:"])
@@ -98,8 +107,24 @@ class Asset extends Component
             $query->where(['like', 'content', "asset:{$asset->id}:"])
                 ->orWhere(['like', 'content', "\"imageId\": \"{$asset->id}\","]);
         }
-        
+
         return $query->all();
+    }
+
+    private function queryHyperElementCache(AssetElement $asset): array
+    {
+        if (! Craft::$app->getPlugins()->isPluginEnabled('hyper')) {
+            return [];
+        }
+
+        return (new Query())
+            ->select(['sourceId as id', 'sourceSiteId as siteId'])
+            ->from(['element_cache' => HyperElementCache::tableName()])
+            ->where([
+                'targetId' => $asset->id,
+                'targetType' => AssetElement::class,
+            ])
+            ->all();
     }
 
     /**


### PR DESCRIPTION
On some of our client sites, we'd like to be able to track asset usage on [Hyper](https://github.com/verbb/hyper) fields as well as with regular Craft relations.

This PR adds logic that checks any Hyper relations for asset usage, but only if the Hyper plugin is present and installed.

I've confirmed that it's working for sites with and without Hyper.

Is this a feature you'd like to add to Asset Usage? 